### PR TITLE
fix: 修复报错

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,7 @@ const wrapCustomSplitConfig = async (
     depsInGroup[group] = await Promise.all(
       packageInfo
         .filter((item): boolean => typeof item === "string")
-        .map((item) => {
-          try {
-            return resolveEntry(item as string, root);
-          } catch (err) {
-            return "";
-          }
-        })
+        .map((item) => resolveEntry(item as string, root))
     );
     depsInGroup[group] = depsInGroup[group].filter((item) => item.length > 0);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,17 +20,20 @@ export async function resolveEntry(
     // Vite 3 will expose pure esm package.
     // Since the api in vite is not stable, we put `vite` in `dependencies` instead of `peerDependencies` and lock the version.
     await dynamicImport("vite");
-
-  return resolvePackageEntry(
-    name,
-    resolvePackageData(name, root || process.cwd(), true)!,
-    true,
-    {
-      isBuild: true,
-      isProduction: process.env.NODE_ENV === "production",
-      isRequire: false,
-      root: process.cwd(),
-      preserveSymlinks: false,
-    }
-  )!;
+  try {
+    return resolvePackageEntry(
+      name,
+      resolvePackageData(name, root || process.cwd(), true)!,
+      true,
+      {
+        isBuild: true,
+        isProduction: process.env.NODE_ENV === "production",
+        isRequire: false,
+        root: process.cwd(),
+        preserveSymlinks: false,
+      }
+    )!;
+  } catch (error) {
+    return "";
+  }
 }


### PR DESCRIPTION
当前版本插件，如下配置，如项目中未安装’react-lazyload‘， 在vite 3.2.3 下会报错
``` ts
chunkSplitPlugin({
    customSplitting: {
        react: ['react', 'react-lazyload'],
      }
  }]
``` 
报错如下：
![image](https://user-images.githubusercontent.com/37234349/203037055-025e2340-a777-4597-8b01-2733d1d4d333.png)
