### PR TITLE
fix: 修复customSplitting

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,5 +29,6 @@ export async function resolveEntry(
     // CJS
     return require.resolve(name, { paths: [root] });
   }
-  return resolve(name, 'file://' + root).replace('file://', '')
+  const fullPath = root.endsWith("/") ? root : root + "/";
+  return resolve(name, "file://" + fullPath).replace("file://", "");
 }


### PR DESCRIPTION
  import-meta-resolve 的 resolve中使用new URL，cwd拿到的地址目录解析，如果不携带 '/'，则会解析出错误的地址
   例如： new URL('./node_modules/react','file:///xx/project').href === 'file:///xx/node_modules/react'